### PR TITLE
Improvements to concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ func main() {
 
 Benchmarks can be found in the `histogram` package and are run on the `beach_medium.jpg` image (1280x1917).
 
+Here are the results on system with `Windows 10 (1909), i7 4770, 16GB RAM, Go 1.13.8`.
+
 ```
-BenchmarkWith32Bins-8             	       5	 244802280 ns/op
-BenchmarkWith32BinsConcurrent-8   	      20	  53650080 ns/op
-BenchmarkWith64Bins-8             	       5	 250596880 ns/op
-BenchmarkWith64BinsConcurrent-8   	      20	  54100025 ns/op
+BenchmarkWith32Bins-8                          5         235398880 ns/op
+BenchmarkWith32BinsConcurrent-8               21          50714243 ns/op
+BenchmarkWith64Bins-8                          5         246097460 ns/op
+BenchmarkWith64BinsConcurrent-8               21          51881000 ns/op
 ```

--- a/histogram/rectangles.go
+++ b/histogram/rectangles.go
@@ -1,0 +1,58 @@
+// Copyright 2019 Alessandro Pomponio. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package histogram
+
+import (
+	"image"
+)
+
+// splitInto splits a rectangle in up to amount parts.
+func splitInto(amount int, rectangle image.Rectangle) []image.Rectangle {
+
+	// Avoid infinite recursion in case amount ends up being odd
+	if amount < 4 {
+		return split(rectangle)
+	}
+
+	// Check if it's worth to stop the recursion
+	xBound := rectangle.Dx()
+	yBound := rectangle.Dy()
+	if xBound < 400 && yBound < 400 {
+		return split(rectangle)
+	}
+
+	rects := split(rectangle)
+	return append(splitInto(amount/2, rects[0]), splitInto(amount/2, rects[1])...)
+
+}
+
+// split splits a Rectangle in two, horizontally.
+func split(r image.Rectangle) []image.Rectangle {
+
+	return []image.Rectangle{
+		{
+
+			Min: image.Point{
+				X: r.Min.X,
+				Y: r.Min.Y,
+			},
+			Max: image.Point{
+				X: ((r.Max.X + r.Min.X) / 2) - 1,
+				Y: r.Max.Y,
+			},
+		},
+		{
+			Min: image.Point{
+				X: (r.Max.X + r.Min.X) / 2,
+				Y: r.Min.Y,
+			},
+			Max: image.Point{
+				X: r.Max.X,
+				Y: r.Max.Y,
+			},
+		},
+	}
+
+}

--- a/histogram/rectangles_test.go
+++ b/histogram/rectangles_test.go
@@ -1,0 +1,90 @@
+package histogram
+
+import (
+	"image"
+	"reflect"
+	"testing"
+)
+
+func Test_split(t *testing.T) {
+	type args struct {
+		r image.Rectangle
+	}
+	tests := []struct {
+		name string
+		args args
+		want []image.Rectangle
+	}{
+		{
+			name: "1000x1000",
+			args: args{r: image.Rect(0, 0, 1000, 1000)},
+			want: []image.Rectangle{image.Rect(0, 0, 499, 1000), image.Rect(500, 0, 1000, 1000)},
+		},
+		{
+			name: "333x333",
+			args: args{r: image.Rect(0, 0, 333, 333)},
+			want: []image.Rectangle{image.Rect(0, 0, 165, 333), image.Rect(166, 0, 333, 333)},
+		},
+		{
+			name: "500x500 no 0,0",
+			args: args{r: image.Rect(1, 1, 500, 500)},
+			want: []image.Rectangle{image.Rect(1, 1, 249, 500), image.Rect(250, 1, 500, 500)},
+		},
+		{
+			name: "747x915 no 0,0",
+			args: args{r: image.Rect(1, 1, 747, 915)},
+			want: []image.Rectangle{image.Rect(1, 1, 373, 915), image.Rect(374, 1, 747, 915)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := split(tt.args.r); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitHorizontally() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_splitInto(t *testing.T) {
+	type args struct {
+		amount    int
+		rectangle image.Rectangle
+	}
+	tests := []struct {
+		name string
+		args args
+		want []image.Rectangle
+	}{
+		{
+			name: "4 rectangles from 1000x1000",
+			args: args{amount: 4, rectangle: image.Rect(0, 0, 1000, 1000)},
+			want: []image.Rectangle{
+				image.Rect(0, 0, 248, 1000),
+				image.Rect(249, 0, 499, 1000),
+				image.Rect(500, 0, 749, 1000),
+				image.Rect(750, 0, 1000, 1000),
+			},
+		},
+		{
+			name: "8 rectangles from 1000x1000",
+			args: args{amount: 8, rectangle: image.Rect(0, 0, 1000, 1000)},
+			want: []image.Rectangle{
+				image.Rect(0, 0, 123, 1000),
+				image.Rect(124, 0, 248, 1000),
+				image.Rect(249, 0, 373, 1000),
+				image.Rect(374, 0, 499, 1000),
+				image.Rect(500, 0, 623, 1000),
+				image.Rect(624, 0, 749, 1000),
+				image.Rect(750, 0, 874, 1000),
+				image.Rect(875, 0, 1000, 1000),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := splitInto(tt.args.amount, tt.args.rectangle); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitInto() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Reduce the overhead caused by using a huge amount of goroutines to compute histograms. 

The concurrent algorithms will now divide the `Rectangle` that makes up the image in up to `runtime.NumProc()` parts to be analyzed concurrently. This gives slight speed improvements and decreases memory consumption.